### PR TITLE
fix: streamline Credit display for csv export

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,5 +1,5 @@
 export function formatCredit(credit: number) {
-    return (credit / 100).toFixed(2)
+    return (credit / 100).toFixed(2).replace('.', ',')
 }
 export function formatDate(date: string) {
     if (!date || date === '') return ''

--- a/src/views/backoffice/BackofficeAccountingPayments.vue
+++ b/src/views/backoffice/BackofficeAccountingPayments.vue
@@ -54,7 +54,7 @@
                   <td className="border-t-2 p-3">
                     {{ translateItem(payment) }}
                   </td>
-                  <td className="border-t-2 p-3">{{ formatAmount(payment.Amount) }} €</td>
+                  <td className="border-t-2 p-3">{{ formatCredit(payment.Amount) }} €</td>
                 </tr>
               </tbody>
             </table>
@@ -72,7 +72,7 @@ import { usePaymentsStore, type Payment } from '@/stores/payments'
 import VueDatePicker from '@vuepic/vue-datepicker'
 import '@vuepic/vue-datepicker/dist/main.css'
 import { computed, onMounted, ref, watch } from 'vue'
-import { exportAsCsv } from '@/utils/utils'
+import { exportAsCsv, formatCredit } from '@/utils/utils'
 
 const keycloakStore = useKeycloakStore()
 const itemsStore = useItemsStore()
@@ -101,10 +101,6 @@ const onRangeStart = (value: any) => {
 const onRangeEnd = (value: any) => {
   endDate.value = value // Update the endDate variable
   store.getPayments(startDate.value, endDate.value)
-}
-
-const formatAmount = (amount: number) => {
-  return (amount / 100).toFixed(2)
 }
 
 const formatTime = (time: string) => {
@@ -165,7 +161,7 @@ const exportTable = () => {
       translateSender(payment.SenderName),
       translateReceiver(payment.ReceiverName),
       translateItem(payment),
-      formatAmount(payment.Amount)
+      formatCredit(payment.Amount)
     ]
   })
 

--- a/src/views/backoffice/BackofficeAccountingPayouts.vue
+++ b/src/views/backoffice/BackofficeAccountingPayouts.vue
@@ -56,7 +56,7 @@
                   >
                     {{ sumItemsForOrder(payment, item.ID) }} €
                   </td>
-                  <td className="border-t-2 p-3">{{ formatAmount(payment.Amount) }} €</td>
+                  <td className="border-t-2 p-3">{{ formatCredit(payment.Amount) }} €</td>
                 </tr>
               </tbody>
             </table>
@@ -75,7 +75,7 @@ import { usePaymentsStore } from '@/stores/payments'
 import { useKeycloakStore } from '@/stores/keycloak'
 import { useItemsStore } from '@/stores/items'
 import { type Payment } from '@/stores/payments'
-import { exportAsCsv } from '@/utils/utils'
+import { exportAsCsv, formatCredit } from '@/utils/utils'
 
 const startOfDay = (date: Date) => {
   const d = new Date(date)
@@ -101,10 +101,6 @@ const onRangeStart = (value: any) => {
 const onRangeEnd = (value: any) => {
   endDate.value = value // Update the endDate variable
   paymentStore.getPayouts(startDate.value, endDate.value)
-}
-
-const formatAmount = (amount: number) => {
-  return (amount / 100).toFixed(2)
 }
 
 const formatTime = (time: string) => {
@@ -145,7 +141,7 @@ const sumItemsForOrder = (payment: any, itemID: number) => {
       }
     }
   })
-  return formatAmount(sum)
+  return formatCredit(sum)
 }
 const exportTable = () => {
   if (!payments.value || payments.value.length == 0) {
@@ -167,7 +163,7 @@ const exportTable = () => {
       translateSender(payment.SenderName),
       payment.AuthorizedBy,
       ...itemAmounts,
-      formatAmount(payment.Amount)
+      formatCredit(payment.Amount)
     ]
   })
 

--- a/src/views/backoffice/BackofficeAccountingSales.vue
+++ b/src/views/backoffice/BackofficeAccountingSales.vue
@@ -43,7 +43,7 @@
                     {{ translateSender(payment.ReceiverName) }}
                   </td>
                   <td className="border-t-2 p-3">{{ $t(getItemName(payment.Item)) }}</td>
-                  <td className="border-t-2 p-3">{{ formatAmount(payment.Amount) }} €</td>
+                  <td className="border-t-2 p-3">{{ formatCredit(payment.Amount) }} €</td>
                 </tr>
               </tbody>
             </table>
@@ -61,7 +61,7 @@ import { ref, computed, watch, onMounted } from 'vue'
 import { usePaymentsStore } from '@/stores/payments'
 import { useKeycloakStore } from '@/stores/keycloak'
 import { useItemsStore } from '@/stores/items'
-import { exportAsCsv } from '@/utils/utils'
+import { exportAsCsv, formatCredit } from '@/utils/utils'
 import { type Payment } from '@/stores/payments'
 
 const startOfDay = (date: Date) => {
@@ -106,10 +106,6 @@ const onRangeEnd = (value: any) => {
   store.getSales(startDate.value, endDate.value)
 }
 
-const formatAmount = (amount: number) => {
-  return (amount / 100).toFixed(2)
-}
-
 const formatTime = (time: string) => {
   const date = new Date(time)
   return date.toLocaleDateString('de-DE', {
@@ -141,7 +137,7 @@ const exportTable = () => {
       formatTime(payment.Timestamp),
       translateSender(payment.ReceiverName),
       getItemName(payment.Item),
-      formatAmount(payment.Amount),
+      formatCredit(payment.Amount),
     ]
   })
 

--- a/src/views/backoffice/BackofficeProductSettings.vue
+++ b/src/views/backoffice/BackofficeProductSettings.vue
@@ -30,7 +30,7 @@
                   </td>
                   <td class="border-t-2 p-3 font-bold">{{ $t(item.Name) }}</td>
                   <td class="border-t-2 p-3">{{ $t(item.Description) }}</td>
-                  <td class="border-t-2 p-3">{{ price(item.Price) }} Euro</td>
+                  <td class="border-t-2 p-3">{{ formatCredit(item.Price) }} Euro</td>
                   <td>
                     <router-link :to="`/backoffice/productsettings/update/${item.ID}`">
                       <button class="p-3 rounded-full bg-lime-600 text-white">
@@ -62,6 +62,7 @@
 <script lang="ts" setup>
 import { useItemsStore } from '@/stores/items'
 import { computed, onMounted } from 'vue'
+import { formatCredit } from '@/utils/utils'
 
 const store = useItemsStore()
 
@@ -71,9 +72,6 @@ onMounted(() => {
 })
 const items = computed(() => store.items)
 const apiUrl = import.meta.env.VITE_API_URL
-const price = (price: number) => {
-  return (price / 100).toFixed(2)
-}
 </script>
 
 <style scoped></style>

--- a/src/views/backoffice/BackofficeVendorsCredits.vue
+++ b/src/views/backoffice/BackofficeVendorsCredits.vue
@@ -73,7 +73,7 @@
 import { vendorsStore } from '@/stores/vendor'
 import { computed, onMounted, ref, watch } from 'vue'
 import keycloak from '@/keycloak/keycloak'
-import { exportAsCsv } from '@/utils/utils'
+import { exportAsCsv, formatCredit } from '@/utils/utils'
 import { type Vendor } from '@/stores/vendor'
 
 const store = vendorsStore()
@@ -89,9 +89,6 @@ onMounted(() => {
     store.getVendors()
   }
 })
-function formatCredit(credit: number) {
-  return (credit / 100).toFixed(2)
-}
 function formatDate(date: string) {
   if (!date || date === '') return ''
   return new Date(date).toLocaleString()

--- a/src/views/backoffice/BackofficeVendorsSummary.vue
+++ b/src/views/backoffice/BackofficeVendorsSummary.vue
@@ -114,7 +114,7 @@ import type { Vendor } from '@/stores/vendor'
 import { ref, computed, onMounted, watch } from 'vue'
 import QRCodeStyling from 'qr-code-styling'
 import keycloak from '@/keycloak/keycloak'
-import { exportAsCsv } from '@/utils/utils'
+import { exportAsCsv, formatCredit } from '@/utils/utils'
 
 import {
   faCreditCard,
@@ -154,10 +154,6 @@ const search = () => {
 const displayVendors = computed(() => {
   return searchQuery.value ? store.filteredVendors : vendors.value
 })
-
-function formatCredit(credit: number) {
-  return (credit / 100).toFixed(2)
-}
 
 // Function to generate QR code only if the button is clicked
 const generateQRCode = async (vendor: Vendor) => {


### PR DESCRIPTION
# Type of change

<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Description
<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
Express your concerns about your changes if you have any.
If your changes are dependent to changes to another repo (backend or frontend) please link it.
Same for other open branches your branch might depends on.
-->
In order to parse a csv in excel float numbers have to be in the form of `1,12` instead of `1.12`.


# Checklist:

- [ ] I have commented my code (or ChatGPT did), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings, neither in my IDE nor in my browser
- [ ] I have added tests that prove my fix is effective or that my feature works