### PR TITLE
Remove delete vendor button

### DIFF
--- a/src/views/backoffice/BackofficeVendorUpdate.vue
+++ b/src/views/backoffice/BackofficeVendorUpdate.vue
@@ -47,18 +47,6 @@ const updateVendor = async () => {
   }
 }
 
-const deleteVendor = async () => {
-  try {
-    if (vendor.value) {
-      await store.deleteVendor(vendor.value.ID)
-      showToast('success', 'VerkäuferIn erfolgreich gelöscht')
-    }
-  } catch (error) {
-    console.error('Error deleting vendor:', error)
-    showToast('error', 'VerkäuferIn konnte nicht gelöscht werden')
-  }
-}
-
 const showToast = (type: string, message: string) => {
   // Set the toast message
   toast.value = { type, message }
@@ -339,22 +327,6 @@ const showToast = (type: string, message: string) => {
                 </div>
               </span>
             </div>
-          </div>
-          <div class="flex place-content-center justify-between">
-            <button
-              type="submit"
-              class="p-3 rounded-full bg-red-600 text-white"
-              @click="deleteVendor"
-            >
-              {{ $t('delete') }}
-            </button>
-            <button
-              type="submit"
-              class="p-3 rounded-full bg-lime-600 text-white"
-              @click="updateVendor"
-            >
-              {{ $t('confirmation') }}
-            </button>
           </div>
         </form>
         <Toast v-if="toast" :toast="toast" />


### PR DESCRIPTION
# Type of change

<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Description
<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
Express your concerns about your changes if you have any.
If your changes are dependent to changes to another repo (backend or frontend) please link it.
Same for other open branches your branch might depends on.
-->
- Removes delete button to not be able to delete vendors anymore, which used to be before on the left bottom on the view below
[
![Screenshot from 2024-05-07 18-41-05](https://github.com/augustin-wien/augustina-frontend/assets/38591956/b012a37e-01c5-4240-b25d-6d773ace1d84)
](url)
# Checklist:

- [ ] I have commented my code (or ChatGPT did), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings, neither in my IDE nor in my browser
- [ ] I have added tests that prove my fix is effective or that my feature works