### PR TITLE
Feat add order to product settings

### DIFF
--- a/src/views/backoffice/BackofficeProductSettings.vue
+++ b/src/views/backoffice/BackofficeProductSettings.vue
@@ -48,6 +48,7 @@ const apiUrl = import.meta.env.VITE_API_URL
                   <th class="p-3">{{ $t('name') }}</th>
                   <th class="p-3">{{ $t('description') }}</th>
                   <th class="p-3">{{ $t('price') }}</th>
+                  <th class="p-3">{{ $t('order') }}</th>
                   <th class="p-3">{{ $t('measure') }}</th>
                 </tr>
               </thead>
@@ -65,7 +66,8 @@ const apiUrl = import.meta.env.VITE_API_URL
                   <td class="border-t-2 p-3 font-bold">{{ $t(item.Name) }}</td>
                   <td class="border-t-2 p-3">{{ $t(item.Description) }}</td>
                   <td class="border-t-2 p-3">{{ formatCredit(item.Price) }} Euro</td>
-                  <td>
+                  <td class="border-t-2 p-3">{{ item.ItemOrder }}</td>
+                  <td class="border-t-2">
                     <router-link :to="`/backoffice/productsettings/update/${item.ID}`">
                       <button class="p-3 rounded-full bg-lime-600 text-white">
                         {{ $t('change') }}

--- a/src/views/backoffice/BackofficeProductUpdate.vue
+++ b/src/views/backoffice/BackofficeProductUpdate.vue
@@ -174,8 +174,20 @@ const previewImage = (image: string | Blob | MediaSource) => {
                   required
                 />
               </div>
+              <label class="block text-gray-700 text-sm font-bold mb-2 pt-3" for="description"
+                >{{ $t('Item order (higher moves the item up)') }}:</label
+              >
+              <div class="flex flex-row">
+                <input
+                  id="description"
+                  v-model="updatedItem.ItemOrder"
+                  class="appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+                  type="text"
+                  required
+                />
+              </div>
               <label class="block text-gray-700 text-sm font-bold mb-2 pt-3" for="price"
-                >{{ $t('price') }}:</label
+                >{{ $t('price') }} (Cent):</label
               >
               <div class="flex flex-row">
                 <input


### PR DESCRIPTION
# Type of change

<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Description
<!--
Please include a summary of the changes and the related issue.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
Express your concerns about your changes if you have any.
If your changes are dependent to changes to another repo (backend or frontend) please link it.
Same for other open branches your branch might depends on.
-->
This enables the possibility to change the order of products in the shop page. The main item always stays on the first spot. 

# Checklist:

- [ ] I have commented my code (or ChatGPT did), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings, neither in my IDE nor in my browser
- [ ] I have added tests that prove my fix is effective or that my feature works