### PR TITLE
added new line to calculate sums for each item

### DIFF
--- a/src/views/backoffice/BackofficeAccountingPayouts.vue
+++ b/src/views/backoffice/BackofficeAccountingPayouts.vue
@@ -164,7 +164,7 @@ const exportTable = () => {
                   </td>
                   <td class="border-t-2 p-3">{{ formatCredit(payment.Amount) }} €</td>
                 </tr>
-                <tr>
+                <tr v-if="payments && payments.length > 0">
                   <td class="border-t-2 p-3"></td>
                   <td class="border-t-2 p-3"></td>
                   <td class="border-t-2 p-3"></td>

--- a/src/views/backoffice/BackofficeAccountingPayouts.vue
+++ b/src/views/backoffice/BackofficeAccountingPayouts.vue
@@ -79,7 +79,7 @@ const sumItemsForOrder = (payment: any, itemID: number) => {
     }
   })
 
-  return formatCredit(sum)
+  return sum
 }
 
 const exportTable = () => {
@@ -160,9 +160,28 @@ const exportTable = () => {
                     :key="`td_${payment.ID}_${item.ID}`"
                     className="border-t-2 p-3"
                   >
-                    {{ sumItemsForOrder(payment, item.ID) }} €
+                    {{ formatCredit(sumItemsForOrder(payment, item.ID)) }} €
                   </td>
-                  <td className="border-t-2 p-3">{{ formatCredit(payment.Amount) }} €</td>
+                  <td class="border-t-2 p-3">{{ formatCredit(payment.Amount) }} €</td>
+                </tr>
+                <tr>
+                  <td class="border-t-2 p-3"></td>
+                  <td class="border-t-2 p-3"></td>
+                  <td class="border-t-2 p-3"></td>
+                  <td v-for="item in items" :key="`td_total_${item.ID}`" class="border-t-2 p-3">
+                    {{
+                      formatCredit(
+                        payments.reduce(
+                          (acc, payment) => acc + sumItemsForOrder(payment, item.ID),
+                          0
+                        )
+                      )
+                    }}
+                    €
+                  </td>
+                  <td class="border-t-2 p-3">
+                    {{ formatCredit(payments.reduce((acc, payment) => acc + payment.Amount, 0)) }} €
+                  </td>
                 </tr>
               </tbody>
             </table>


### PR DESCRIPTION
# Type of change

<!-- Please delete options that are not relevant. -->
- [ ] New feature (non-breaking change which adds functionality)

# Description
added a new line for calculating sums of payouts for each item

# Checklist:

- [ ] I have commented my code (or ChatGPT did), particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings, neither in my IDE nor in my browser
- [ ] I have added tests that prove my fix is effective or that my feature works